### PR TITLE
bypass `sed -i` for portability.

### DIFF
--- a/utils/build.sh
+++ b/utils/build.sh
@@ -22,8 +22,7 @@ fi
 mkdir $OUTDIR
 
 OUTFILE_H="${OUTDIR}/RNACI.h"
-cp "${PROJROOT}/src/API.h" ${OUTFILE_H}
-sed -i -e "s/RNACI_FUNTYPE//g" ${OUTFILE_H}
+sed -e "s/RNACI_FUNTYPE//g" < "${PROJROOT}/src/API.h" >> ${OUTFILE_H}
 
 OUTFILE="${OUTDIR}/RNACI.c"
 


### PR DESCRIPTION
`sed -i` requires different arguments depending on the implementation. It's safer (and probably uses less resources!) to just use stdin/stdout rather than `cp` and `sed -i`.